### PR TITLE
Add examples for changing behavior on end slashes input

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ no dependencies and relies only on the Go standard library.
 - `func ExtractInPlace(archivePath string) error`: extract a tar archive from
   `archivePath` "in-place", ie `archivePath` is removed after the archive has
   been extracted (note: it expects `archivePath` to have a file extension).
+
+## Notes
+
+- As pointed out in the documentation of `Create` and `CreateInPlace` (see [#1](https://github.com/Rolinh/targo/issues/1)), the use of [filepath.Dir](https://golang.org/pkg/path/filepath/#Dir) introduce different behavior depending on the way you define your path:
+  - With __'/foo/bar'__, `filepath.Dir` will consider __'bar'__ as the last token and return __'/foo'__. This will include the '__bar__' directory to be part of the tar as the root directory.
+  - With __'/foo/bar/'__, `filepath.Dir` will consider __'/.'__ as the last token and return __'/foo/bar'__. This will ignore the '__bar__' directory and there will be not root directory in the resulting tar.

--- a/targo.go
+++ b/targo.go
@@ -118,7 +118,7 @@ The .tar suffix will be added to dirPath once the archive is created.
 
 Due to filepath.Dir behavior, calling this function with a dirPath
 containing an end slash or not will change the output result. See Create
-examples.
+documentation and examples.
 */
 func CreateInPlace(dirPath string) error {
 	if err := Create(dirPath+".tar", dirPath); err != nil {

--- a/targo.go
+++ b/targo.go
@@ -14,8 +14,13 @@ import (
 	"strings"
 )
 
-// Create creates a tar archive from a directory.
-// The resulting tar archive format is in POSIX.1 format.
+/*
+Create creates a tar archive from a directory.
+The resulting tar archive format is in POSIX.1 format.
+
+Due to filepath.Dir behavior, calling this function with a dirPath containing an end slash
+or not will change the output result.
+*/
 func Create(destPath, dirPath string) error {
 	fi, err := os.Stat(dirPath)
 	if err != nil {
@@ -104,9 +109,15 @@ func Create(destPath, dirPath string) error {
 	return err
 }
 
-// CreateInPlace creates a tar archive from a directory in place which means
-// that the original directory is removed after the tar archive is created.
-// The .tar suffix will be added to dirPath once the archive is created.
+/*
+CreateInPlace creates a tar archive from a directory in place which means
+that the original directory is removed after the tar archive is created.
+The .tar suffix will be added to dirPath once the archive is created.
+
+Due to filepath.Dir behavior, calling this function with a dirPath
+containing an end slash or not will change the output result. See Create
+examples.
+*/
 func CreateInPlace(dirPath string) error {
 	if err := Create(dirPath+".tar", dirPath); err != nil {
 		return err

--- a/targo.go
+++ b/targo.go
@@ -19,7 +19,9 @@ Create creates a tar archive from a directory.
 The resulting tar archive format is in POSIX.1 format.
 
 Due to filepath.Dir behavior, calling this function with a dirPath containing an end slash
-or not will change the output result.
+or not will change the output result. A dirPath without an ending slash will produce a tar
+with the root directory of the given path while a dirPath with an ending slash will produce 
+a tar without the root directory of this given path.
 */
 func Create(destPath, dirPath string) error {
 	fi, err := os.Stat(dirPath)

--- a/targo_test.go
+++ b/targo_test.go
@@ -32,6 +32,20 @@ var (
 	voidPath          = parentPath + "/void"
 )
 
+//A path without an ending slash will produce a tar
+//that containing the root directory specified in dirPath.
+func ExampleCreate() {
+	Create(bardirPath+".tar", bardirPath)
+	// Will result in a tar containing the bardir at its root level
+}
+
+//A path with an ending slash
+//will produce a tar that does not contain the root directory specified in dirPath.
+func ExampleCreate_slash() {
+	Create(bardirPath+".tar", bardirPath+"/")
+	// Will result in a tar containing the files and folders inside bardir at its root level
+}
+
 func TestCreateExtract(t *testing.T) {
 	if err := Create(barPath+".tar", barPath); err == nil {
 		t.Fatal(errors.New("not a directory: " + barPath))


### PR DESCRIPTION
Added a note on the README.md and add example for targo.Create.

This refers to #1. 
